### PR TITLE
Enable edit command on compile-multi-embark

### DIFF
--- a/compile-multi.el
+++ b/compile-multi.el
@@ -49,7 +49,7 @@
 To override the interface you must define a variant of
 `compile-multi-read-actions' that accepts an interface argument matching the
 value set here."
-  :type '(optional symbol))
+  :type '(choice (const nil) symbol))
 
 (defvar compile-multi-history nil
   "History of completions chosen with `compile-multi'.")
@@ -68,7 +68,7 @@ has significance when `compile-multi-annotate-cmds' is true."
 (defcustom compile-multi-annotate-limit 48
   "Truncate any annotations longer than this limit.
 Set to nil to disable truncation."
-  :type '(optional integer))
+  :type '(choice integer (const nil)))
 
 (defcustom compile-multi-group-cmds 'group-and-replace
   "Group commands with the same `compile-multi' root prefix."
@@ -264,7 +264,8 @@ The plist will contain a command and an optional annotation property for task."
 If set this function will be called prior to determining compilation triggers
 and actions and `default-directory' will be set to the result. If the result
 is nil then `default-directory' will not be changed."
-  :type '(optional function))
+  :type '(choice function
+                 (const :tag "`default-directory'" nil)))
 
 ;;;###autoload
 (defun compile-multi (&optional query)

--- a/extensions/compile-multi-embark/compile-multi-embark.el
+++ b/extensions/compile-multi-embark/compile-multi-embark.el
@@ -38,6 +38,8 @@
 (defvar compile-multi-embark-command-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map embark-general-map)
+    (define-key map "e" #'compile-multi-embark-edit)
+    (define-key map "g" #'recompile)
     map)
   "Keymap active in `compile-multi' `embark' sessions.")
 
@@ -51,6 +53,13 @@ TYPE should always be `compile-multi'."
   (let ((command (get-text-property 0 'compile-multi--task target)))
     (cl-assert command 'show-args "Encountered compile-multi candidate with no command")
     (cons type command)))
+
+(defun compile-multi-embark-edit (cmd)
+  "Edit before running `compile' on CMD."
+  (cond
+   ((stringp cmd) (compile (compilation-read-command cmd)))
+   ((functionp cmd) (eval-expression (read--expression "Eval: " (format "(%s)" cmd))))
+   (t (error "Don't know how to run the command %s" cmd))))
 
 ;;;###autoload
 (define-minor-mode compile-multi-embark-mode


### PR DESCRIPTION
Hi! Thanks for the package.

I've added support for editing command from `compile-multi-embark`, to sort of achieve the behaviour of `C-u M-x compile-multi`.

I've also taken the luxury to add `recompile` and fix `defcustom`s' type.