### PR TITLE
README: Add compile-multi-nerd-icons MELPA badge

### DIFF
--- a/README.org
+++ b/README.org
@@ -195,6 +195,9 @@ tools.
 
 ** compile-multi-nerd-icons
 
+#+html: <p align="right">
+#+html:   <a href="https://melpa.org/#/compile-multi-nerd-icons"><img alt="MELPA" src="https://melpa.org/packages/compile-multi-nerd-icons-badge.svg"/></a>
+#+html: </p>
 
    This extension adds a handler to [[https://github.com/rainstormstudio/nerd-icons-completion][nerd-icons-completion]] for affixating
    compile-multi with nerd icons related the compile-multi type. You have to setup


### PR DESCRIPTION
The package just got accepted into MELPA (see https://github.com/melpa/melpa/pull/9183#issuecomment-2366908743).

I'm making this Pull Request right now but I think it's best for you to wait until the package is actually there ([here's a link for us to track this](https://melpa.org/#/compile-multi-nerd-icons)).