### PR TITLE
README: Add compile-multi-nerd-icons to the Table of Contents

### DIFF
--- a/README.org
+++ b/README.org
@@ -34,6 +34,7 @@ tools.
 - [[#extensions][Extensions]]
   - [[#consult-multi-compile][consult-multi-compile]]
   - [[#compile-multi-all-the-icons][compile-multi-all-the-icons]]
+  - [[#compile-multi-nerd-icons][compile-multi-nerd-icons]]
   - [[#compile-multi-embark][compile-multi-embark]]
 
 * Installation


### PR DESCRIPTION
Seems like I missed this one (I don't have a TOC package installed because they didn't work for me, but I'll check your config out to add one).